### PR TITLE
Token refresh API

### DIFF
--- a/api/models/sp_user.go
+++ b/api/models/sp_user.go
@@ -64,3 +64,9 @@ type SpGroupMessage struct {
 	CreatedAt   time.Time `json:"created_at" gorm:"default:NOW()"`
 	Writer      string    `json:"writer"`
 }
+
+type RefreshTokenResponse struct {
+	SpUser       *SpUser `json:"user"`
+	AccessToken  string  `json:"access_token"`
+	RefreshToken string  `json:"refresh_token"`
+}

--- a/api/server/instance/server.go
+++ b/api/server/instance/server.go
@@ -172,4 +172,7 @@ func (s *Server) RegisterHandlers() {
 	s.r.HandleFunc("/sp/users/update", utils.AuthSP(spuser.CreateUpdateSPUserHandler(s.DB)).ServeHTTP).
 		Methods(http.MethodPost)
 
+	s.r.HandleFunc("/sp/refresh", utils.AuthRefreshSP(spuser.CreateRefreshSPUserTokenHandler(s.DB)).ServeHTTP).
+		Methods(http.MethodPost)
+
 }


### PR DESCRIPTION
API to refresh both access and refresh token.
It can only be called using a valid refresh token.